### PR TITLE
Radfish-246 fix broken links doc

### DIFF
--- a/docs/building-your-application/frontend-development-guide.md
+++ b/docs/building-your-application/frontend-development-guide.md
@@ -10,22 +10,22 @@ The purpose of this document is to serve as a technical guide to building fronte
 
 ### Outline
 
-- [Problem Definition / What kind of NOAA applications are there and how are they used?](https://www.notion.so/DRAFT-Work-in-progress-RADFish-Frontend-Application-Development-Guide-dc3c5589b019458e8b5ab3f4293ec183?pvs=21)
+- [Problem Definition / What kind of NOAA applications are there and how are they used?](#problem-definition)
   - Commercial Fishers reporting **fish catch data**
     - Description of this use case
   - Fish Dealers and Processors reporting **fish purchase data**
     - Description of this use case
   - Fishery Observers reporting **fishery stats data**
     - Description of this use case
-- [What unique considerations need to be made when building a frontend application for NOAA?](https://www.notion.so/DRAFT-Work-in-progress-RADFish-Frontend-Application-Development-Guide-dc3c5589b019458e8b5ab3f4293ec183?pvs=21)
+- [What unique considerations need to be made when building a frontend application for NOAA?](#what-unique-considerations-need-to-be-made-when-building-a-frontend-application-for-noaa)
   - Offline use out at sea in absence of a network connection
   - Multi-entry forms for bulk entering of fish data
-- [Development Standards](https://www.notion.so/DRAFT-Work-in-progress-RADFish-Frontend-Application-Development-Guide-dc3c5589b019458e8b5ab3f4293ec183?pvs=21)
+- [Development Standards](http://localhost:3000/documentation/docs/building-your-application/development-standards)
   - USWDS
   - NOAA Branding Guidelines and Style Guide
   - 508 Compliance
   - 18F Software Development Standards
-- [Development Lifecycle](https://www.notion.so/DRAFT-Work-in-progress-RADFish-Frontend-Application-Development-Guide-dc3c5589b019458e8b5ab3f4293ec183?pvs=21)
+- Development Lifecycle
   - Project Setup
   - Development of Application Components
   - Routing and Navigation

--- a/docs/building-your-application/frontend-development-guide.md
+++ b/docs/building-your-application/frontend-development-guide.md
@@ -20,7 +20,7 @@ The purpose of this document is to serve as a technical guide to building fronte
 - [What unique considerations need to be made when building a frontend application for NOAA?](#what-unique-considerations-need-to-be-made-when-building-a-frontend-application-for-noaa)
   - Offline use out at sea in absence of a network connection
   - Multi-entry forms for bulk entering of fish data
-- [Development Standards](http://localhost:3000/documentation/docs/building-your-application/development-standards)
+- [Development Standards](https://nmfs-radfish.github.io/documentation/docs/building-your-application/development-standards)
   - USWDS
   - NOAA Branding Guidelines and Style Guide
   - 508 Compliance

--- a/docs/building-your-application/patterns/debugging.md
+++ b/docs/building-your-application/patterns/debugging.md
@@ -8,7 +8,7 @@ Debugging plays pivotal roles in the development of Progressive Web Applications
 
 There are several common strategies for debugging a web application during development. These include but are not limited to:
 
-- Adding breakpoints in code editor: [See vscode documentation](https://www.notion.so/Code-Style-Guide-65a23205922c409098ee7efbe1189773?pvs=21)
+- Adding breakpoints in code editor: [See vscode documentation](https://code.visualstudio.com/docs/editor/debugging#_breakpoints)
 - Adding logs to the development console: [See MDN documentation](https://developer.mozilla.org/en-US/blog/learn-javascript-console-methods/)
 - Using the network console: [See Chrome DevTools documentation](https://developer.chrome.com/docs/devtools/network)
 - Using an HTTP client like Postman to test API calls: [See Postman documentation](https://learning.postman.com/docs/introduction/overview/)

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -40,10 +40,6 @@ const config = {
       ({
         docs: {
           sidebarPath: "./sidebars.js",
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-        //   editUrl:
-        //     "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
         },
         theme: {
           customCss: "./src/css/custom.css",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,8 +42,8 @@ const config = {
           sidebarPath: "./sidebars.js",
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
-          editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+        //   editUrl:
+        //     "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
         },
         theme: {
           customCss: "./src/css/custom.css",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,6 +17,14 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
+        <div className={styles.buttons}>
+          <Link
+            className="button button--secondary button--lg"
+            to="/docs/getting-started"
+          >
+            Get started with RADFish
+          </Link>
+        </div>
       </div>
     </header>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,14 +17,6 @@ function HomepageHeader() {
           {siteConfig.title}
         </Heading>
         <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="button button--secondary button--lg"
-            to="/docs/category/getting-started"
-          >
-            RADFish Tutorial - 5min ⏱️
-          </Link>
-        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
## Issue:
[RADFISH-246 Documentation: Fix broken links](https://apps-st.fisheries.noaa.gov/jira/secure/RapidBoard.jspa?rapidView=856&projectKey=RADFISH&view=planning&selectedIssue=RADFISH-246&issueLimit=100)

## Changes:
- Remove CTA -5 min button
- Remove "Edit this Page" functionality that is shown at the end of pages
- Change notion links to their correct respected links
