### PR TITLE
#65 - Docs - Surface Examples Higher

### DIFF
--- a/docs/building-your-application/_category_.json
+++ b/docs/building-your-application/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Building Your Application",
-  "position": 2,
+  "position": 3,
   "link": {
     "type": "generated-index"
   }

--- a/docs/building-your-application/available-scripts/running-example.md
+++ b/docs/building-your-application/available-scripts/running-example.md
@@ -1,6 +1,6 @@
 # Running an Example
 
-RADFish ships with several different boilerplate examples that demonstrate core pieces of functionality identified as critical for NOAA application development. You can use these examples as a reference point to build out your own implementation, or simply to get inspiration for your own design patterns with some pre-defined best practices.
+RADFish ships with several different [boilerplate examples](../../examples-and-templates#examples) that demonstrate core pieces of functionality identified as critical for NOAA application development. You can use these examples as a reference point to build out your own implementation, or simply to get inspiration for your own design patterns with some pre-defined best practices.
 
 For instance, there is an example that demonstrates how to build a multi-step form that caches each step within IndexedDB, so that it can be referenced without having network connection. In order to run this example, you can run the following command:
 

--- a/docs/examples-and-templates.md
+++ b/docs/examples-and-templates.md
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Starting from a boilerplate
+# Examples and Templates
 
 ## Examples
 
@@ -10,7 +10,7 @@ Examples are small, scoped projects that are meant to demonstrate how to impleme
 
 These examples are meant to be a reference for any RADFish project. While these examples can certainly be used as a starting point to build out a new RADFish application, we still suggest starting with a fresh `react-javascript` template (see below).
 
-You can visualize the source code for each example at the open source repository for the overall RADFish [boilerplate](https://github.com/NMFS-RADFish/boilerplate/tree/main/examples). Each of these examples can be cloned and run separately as you are working with each from the RADFish CLI. To learn more about how to run these scripts, please reference the [running examples](./available-scripts/running-example.md) section of this documentation
+You can visualize the source code for each example at the open source repository for the overall RADFish [boilerplate](https://github.com/NMFS-RADFish/boilerplate/tree/main/examples). Each of these examples can be cloned and run separately as you are working with each from the RADFish CLI. To learn more about how to run these scripts, please reference the [running examples](./building-your-application/available-scripts/running-example.md) section of this documentation
 
 Below are a list of pre-built examples that you can use as a starting point for your application. With exception of the `Main` example, these are all scoped to one core feature. Whereas the `Main` example encapsulates many of these features into a more fully built example. Note that the `Main` example may be more complex than you may like if you are just familiarizing yourself with the RADFish ecosystem.
 
@@ -26,7 +26,7 @@ Below are a list of pre-built examples that you can use as a starting point for 
 1. [Server Sync](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/server-sync/README.md)
 1. [Simple Table](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/simple-table/README.md)
 
-# Templates
+## Templates
 
 Templates are meant to be a clean starting point for a new RADFish project. These templates are framework specific. Note that at the time of this writing, only the `react-javascript` template is supported, though new frameworks/languages are planned to be supported in the future!
 

--- a/docs/libraries/_category_.json
+++ b/docs/libraries/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Libraries",
-  "position": 3,
+  "position": 4,
   "link": {
     "type": "generated-index"
   }

--- a/docs/technical-decision-log/_category_.json
+++ b/docs/technical-decision-log/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "RADFish Technical Decision Log",
-  "position": 3,
+  "position": 5,
   "link": {
     "type": "generated-index"
   }


### PR DESCRIPTION
issue #65 

- Moved **Starting from a boilerplate** to the top and renamed to **Examples and Templates**
- Update positions of left menu items
- Add link to **Examples and Templates** in **Running an example** doc file

https://github.com/user-attachments/assets/b14a498d-afd0-4b38-9a04-7ba3ae335681

