### PR TITLE
74 - Change GitHub target link to root project in GitHub

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,7 +79,7 @@ const config = {
             label: "About",
           },
           {
-            href: "https://github.com/nmfs-radfish/documentation",
+            href: "https://github.com/NMFS-RADFish",
             label: "GitHub",
             position: "right",
           },


### PR DESCRIPTION
issue #74 