### PR TITLE
79 Docs - Add config so card summaries do not show on the actual documentation page

### DIFF
--- a/docs/developer-documentation/building-your-application/development-life-cycle.md
+++ b/docs/developer-documentation/building-your-application/development-life-cycle.md
@@ -1,10 +1,9 @@
 ---
 sidebar_position: 3
+description: Setting up web projects with RADFish
 ---
 
 # Project Setup
-
-Setting up web projects with RADFish.
 
 When setting up a web application within the NOAA ecosystem, it’s imperative that you setup your project properly in order to make life easier as development progresses. A strong setup includes proper development standards ie: File structure, linting, core frameworks, build tooling, etc.
 

--- a/docs/developer-documentation/building-your-application/development-standards.md
+++ b/docs/developer-documentation/building-your-application/development-standards.md
@@ -1,10 +1,9 @@
 ---
 sidebar_position: 4
+description: USWDS, NOAA branding and Styling, and 508 compliance
 ---
 
 # Development Standards
-
-## NOAA development standards, branding, and 508 compliance
 
 **USWDS**
 

--- a/docs/developer-documentation/building-your-application/frontend-development-guide.md
+++ b/docs/developer-documentation/building-your-application/frontend-development-guide.md
@@ -1,10 +1,9 @@
 ---
 sidebar_position: 1
+description: The purpose of RADFish
 ---
 
 # How RADFish Can Help You
-
-The purpose of RADFish.
 
 ### **Purpose**
 

--- a/docs/developer-documentation/building-your-application/patterns/apiservice.md
+++ b/docs/developer-documentation/building-your-application/patterns/apiservice.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 3
+description: Use any network library to handle HTTP requests
 ---
 
 # Integrating with Backend Services

--- a/docs/developer-documentation/building-your-application/patterns/components.md
+++ b/docs/developer-documentation/building-your-application/patterns/components.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Learn to build and structure your components
 ---
 
 # Components and Usage
@@ -10,7 +11,7 @@ When building applications with React, there is an existing component library, [
 
 For reference on the full `react-uswds` library, you can reference the deployed storybook:
 
-[https://trussworks.github.io/react-uswds/](https://trussworks.github.io/react-uswds/?path=/story/welcome--welcome)
+[https://trussworks.github.io/react-uswds/](https://trussworks.github.io/react-uswds/?path=/docs/welcome--docs)
 
 **Example**
 
@@ -44,4 +45,4 @@ For more specific information regarding how to build a form, you can reference t
 
 Tables are also a key component type for all NOAA applications. These components are usually meant for visualizing data in a user friendly manner. However, there are cases where having this data also be writable (ie: submittable) to a backend. Utilizing caching strategies with IndexedDB is an effective way to ensure that these types of components remain fully functional when offline.
 
-Form more specific information regarding how to build a table, you can reference the [State Management](./state-management.md) portion of this documentation.
+For more specific information regarding how to build a table, you can reference the [State Management](./state-management.md) portion of this documentation.

--- a/docs/developer-documentation/building-your-application/patterns/debugging.md
+++ b/docs/developer-documentation/building-your-application/patterns/debugging.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+description: Strategies for debugging your applications
 ---
 
 # Debugging

--- a/docs/developer-documentation/building-your-application/patterns/mock-api.md
+++ b/docs/developer-documentation/building-your-application/patterns/mock-api.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 4
+description: Simulate backend responses to unblock your development
 ---
 
 # Mock API

--- a/docs/developer-documentation/building-your-application/patterns/navigation.md
+++ b/docs/developer-documentation/building-your-application/patterns/navigation.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: Handle navigation patterns in your application
 ---
 
 # Navigation

--- a/docs/developer-documentation/building-your-application/patterns/offline-storage.md
+++ b/docs/developer-documentation/building-your-application/patterns/offline-storage.md
@@ -1,6 +1,7 @@
 ---
 sidebar_position: 8
 title: "Offline Storage"
+description: Implement offline storage functionality (Coming soon)
 ---
 
 # Offline Storage

--- a/docs/developer-documentation/building-your-application/patterns/routing.md
+++ b/docs/developer-documentation/building-your-application/patterns/routing.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+description: Manage app routes with React Router
 ---
 
 # Routing
@@ -57,7 +58,7 @@ This setup provides a navigation link to the home page.
 
 ### Example Code
 
-You can view the full example of the routing setup in the `App.jsx` file in the GitHub repository: [github/boilerplate/templates/react-javascript/src/App.jsx](https://github.com/your-repository/boilerplate/templates/react-javascript/src/App.jsx)
+You can view the full example of the routing setup in the `App.jsx` file in the GitHub repository: [github/boilerplate/templates/react-javascript/src/App.jsx](https://github.com/NMFS-RADFish/boilerplate/blob/main/templates/react-javascript/src/App.jsx)
 
 ```jsx
 import { BrowserRouter, Routes, Route, Link } from "react-router-dom";

--- a/docs/developer-documentation/building-your-application/patterns/state-management.md
+++ b/docs/developer-documentation/building-your-application/patterns/state-management.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: An overview of managing application state effectively
 ---
 
 # State Management
@@ -12,9 +13,9 @@ In the world of NOAA web app development, we frequently deal with various forms 
 
 Our applications are not just repositories of static data; they are dynamic platforms where data constantly evolves. State management is essential for several reasons:
 
-Stay Updated: It allows us to display the most up-to-date information to our users, ensuring accuracy and reliability.
-Work Offline: It enables our apps to function even in the absence of an internet connection, storing data locally and syncing it back to our servers once a connection is re-established.
-Be Fast and Responsive: It helps our apps to react swiftly to user interactions and data changes, providing a smooth and efficient user experience.
+- **Stay Updated**: It allows us to display the most up-to-date information to our users, ensuring accuracy and reliability.
+- **Work Offline**: It enables our apps to function even in the absence of an internet connection, storing data locally and syncing it back to our servers once a connection is re-established.
+- **Be Fast and Responsive**: It helps our apps to react swiftly to user interactions and data changes, providing a smooth and efficient user experience.
 A Simple Way to Manage State: Using React Context
 
 For sharing and managing state across different parts of our applications, we use a feature called React Context. This is akin to creating a communal space where any component of our app can easily access or update shared information, eliminating the complexity of passing data through multiple layers.

--- a/docs/developer-documentation/building-your-application/patterns/testing.md
+++ b/docs/developer-documentation/building-your-application/patterns/testing.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: Ensure code quality with Vitest and React Testing Library
 ---
 
 # Testing
@@ -70,7 +71,7 @@ Vitest and React Testing Library is included in the RADFish framework by default
 
 ### **Debugging Broken or Failed Tests**
 
-1. **Review Test Output**: Viteest provides detailed error messages. Analyze them to understand the failure.
+1. **Review Test Output**: Vitest provides detailed error messages. Analyze them to understand the failure.
 2. **Use `console.log`**: Temporarily add **`console.log`** statements within your test to inspect values.
 3. **Check for Async Issues**: Ensure promises are resolved and state updates are completed.
 

--- a/docs/developer-documentation/libraries/radfish.md
+++ b/docs/developer-documentation/libraries/radfish.md
@@ -1,11 +1,10 @@
 ---
 sidebar_position: 1
+description: Core modules to build a RADFish app
 ---
-
-radfish NPM provides core, framework-agnostic tools.
 
 # `radfish`
 
-The `radfish` NPM package contains the core Javascript modules needed to power any RADFish project. The idea is that these modules are framework agnostic, and should be fully functional whether you are building an application in React, Svelete, or even Vanilla JavaScript.
+The `radfish` NPM package contains the core Javascript modules needed to power any RADFish project. The idea is that these modules are framework agnostic, and should be fully functional whether you are building an application in React, Svelte, or even Vanilla JavaScript.
 
 This library is open source and can be found here: [https://www.npmjs.com/package/@nmfs-radfish/radfish](https://www.npmjs.com/package/@nmfs-radfish/radfish)

--- a/docs/developer-documentation/libraries/react-radfish.md
+++ b/docs/developer-documentation/libraries/react-radfish.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 2
+description: Modules to build a RADFish app in React
 ---
 
 # `react-radfish`

--- a/docs/developer-documentation/technical-decision-log/dexie.md
+++ b/docs/developer-documentation/technical-decision-log/dexie.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 9
+description: Simplifies working with IndexedDB for offline data storage
 ---
 
 # Dexie for Offline Data

--- a/docs/developer-documentation/technical-decision-log/dexie.md
+++ b/docs/developer-documentation/technical-decision-log/dexie.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 9
-description: Simplifies working with IndexedDB for offline data storage
+description: Simplifies working with IndexedDB
 ---
 
 # Dexie for Offline Data

--- a/docs/developer-documentation/technical-decision-log/jsdocs.md
+++ b/docs/developer-documentation/technical-decision-log/jsdocs.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 8
-description: Accessible and easy to adopt for government contractors
+description: Accessible and easy to adopt
 ---
 
 # JavaScript w/JS Docs

--- a/docs/developer-documentation/technical-decision-log/jsdocs.md
+++ b/docs/developer-documentation/technical-decision-log/jsdocs.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 8
+description: Accessible and easy to adopt for government contractors
 ---
 
 # JavaScript w/JS Docs

--- a/docs/developer-documentation/technical-decision-log/mock-service-worker.md
+++ b/docs/developer-documentation/technical-decision-log/mock-service-worker.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 6
+description: RADFish's offline functionality requires service mocking
 ---
 
 # Mock Service Worker

--- a/docs/developer-documentation/technical-decision-log/mock-service-worker.md
+++ b/docs/developer-documentation/technical-decision-log/mock-service-worker.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 6
-description: RADFish's offline functionality requires service mocking
+description: Required for offline functionality
 ---
 
 # Mock Service Worker

--- a/docs/developer-documentation/technical-decision-log/prettier.md
+++ b/docs/developer-documentation/technical-decision-log/prettier.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 7
-description: Ensures consistent code quality and style across the project
+description: Ensures consistent code quality and style
 ---
 
 # Prettier/ESLint

--- a/docs/developer-documentation/technical-decision-log/prettier.md
+++ b/docs/developer-documentation/technical-decision-log/prettier.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 7
+description: Ensures consistent code quality and style across the project
 ---
 
 # Prettier/ESLint

--- a/docs/developer-documentation/technical-decision-log/purpose.md
+++ b/docs/developer-documentation/technical-decision-log/purpose.md
@@ -1,10 +1,9 @@
 ---
 sidebar_position: 1
+description: Provides clarity around technical decisions
 ---
 
 # Purpose
-
-Provides clarity around technical decisions.
 
 In order to provide transparency and clarity around the technical decisions we have made, we wanted to provide a technical decision justification for the chosen technologies and frameworks of RADFish.
 

--- a/docs/developer-documentation/technical-decision-log/tanstack.md
+++ b/docs/developer-documentation/technical-decision-log/tanstack.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 11
+description: Offers flexible state management
 ---
 
 # Tanstack for State Management

--- a/docs/developer-documentation/technical-decision-log/trussworks.md
+++ b/docs/developer-documentation/technical-decision-log/trussworks.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 5
-description: Trussworks adheres to US Web Design Standards
+description: Adherence to US Web Design Standards
 ---
 
 # Trussworks Component Library

--- a/docs/developer-documentation/technical-decision-log/trussworks.md
+++ b/docs/developer-documentation/technical-decision-log/trussworks.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 5
+description: Trussworks adheres to US Web Design Standards
 ---
 
 # Trussworks Component Library

--- a/docs/developer-documentation/technical-decision-log/workbox.md
+++ b/docs/developer-documentation/technical-decision-log/workbox.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 10
-description: Streamlines service worker management for improved caching
+description: Service worker management for improved caching
 ---
 
 # Workbox

--- a/docs/developer-documentation/technical-decision-log/workbox.md
+++ b/docs/developer-documentation/technical-decision-log/workbox.md
@@ -1,5 +1,6 @@
 ---
 sidebar_position: 10
+description: Streamlines service worker management for improved caching
 ---
 
 # Workbox


### PR DESCRIPTION
issue #79 

- fix summaries issue so that it doesn't show on actual page
- fix some broken links
- fix some formatting
- add missing summaries to **Libraries** and **RADFish Technical Decision Log**
  
  <img width="1645" alt="Screenshot 2024-09-20 at 11 54 35 AM" src="https://github.com/user-attachments/assets/19aa70e6-0589-4a21-b894-8fbca8b24ce6">

  <img width="1623" alt="Screenshot 2024-09-20 at 12 24 44 PM" src="https://github.com/user-attachments/assets/32c0ca59-b740-482a-8527-35062cc59a6d">


