### PR TITLE
105 Docs  - Homepage style updates

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -90,7 +90,7 @@ export default function HomepageFeatures() {
       <RADFishHero />
       <section className={styles.features}>
         <div className="container">
-          <div className="row">
+          <div className={clsx("row", styles.cardContainerRow)}>
             {FeatureList.map((props, idx) => (
               <Feature key={idx} {...props} />
             ))}

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -35,6 +35,10 @@
   color: #666;
 }
 
+.cardContainerRow {
+  gap: 15px;
+}
+
 .card {
   border: 1px solid #ddd;
   border-radius: 8px;
@@ -43,10 +47,11 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
   transition: transform 0.2s ease-in-out;
-  height: 300px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  color: #000;
+  height: 100%;
 }
 
 .card:hover {
@@ -68,4 +73,10 @@
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
+}
+
+@media screen and (min-width: 996px) {
+  .cardContainerRow {
+    gap: 0;
+  }
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -19,7 +19,7 @@
   font-size: 2rem;
   font-weight: bold;
   margin-bottom: 20px;
-  color: #000;
+  color: black;
 }
 
 .heroSubtitle {
@@ -42,7 +42,7 @@
 .card {
   border: 1px solid #ddd;
   border-radius: 8px;
-  background-color: #fff;
+  background-color: white;
   padding: 20px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
@@ -50,7 +50,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  color: #000;
+  color: black;
   height: 100%;
 }
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -42,7 +42,7 @@
 }
 
 .button {
-  border: 1.5px solid #000000;
+  border: 1.5px solid black;
   border-radius: 0;
   font-weight: 600;
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,6 +6,8 @@
 
 /* You can override the default Infima variables here. */
 :root {
+  --radfish-primary-blue: #205493;
+
   --ifm-color-primary: #205493;
   --ifm-color-primary-dark: #1d4c84;
   --ifm-color-primary-darker: #1b477d;
@@ -33,6 +35,7 @@
   --ifm-color-primary-lightest: #4fddbf;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
+
 
 .buttons {
   display: flex;

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -11,23 +11,18 @@ import HomepageFeatures from "../components/HomepageFeatures";
 function HomepageHeader() {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <header
-      className={clsx("hero hero--primary", styles.heroBanner)}
-      style={{
-        height: "65vh",
-        backgroundImage: "url(img/hero-banner.webp)",
-        backgroundSize: "cover",
-        backgroundPosition: "bottom",
-      }}
-    >
-      <div className="container">
-        <Heading as="h1" className={clsx("hero__title", styles.heroTextColor)}>
+    <header className={clsx("hero", styles.heroBanner)}>
+      <div className={clsx("container", styles.heroContainer)}>
+        <Heading
+          as="h1"
+          className={clsx(styles.heroHeading, styles.heroTextColor)}
+        >
           {siteConfig.title}
         </Heading>
-        <p className={clsx("hero__subtitle", styles.heroTextColor)}>
+        <p className={clsx(styles.heroSubHeading, styles.heroTextColor)}>
           {siteConfig.tagline}
         </p>
-        <div className="buttons">
+        <div className={clsx("buttons", styles.heroButtons)}>
           <Link
             className={clsx("button button--primary", styles.heroButton)}
             to="/developer-documentation/getting-started"

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -8,7 +8,7 @@
   text-align: center;
   position: relative;
   overflow: hidden;
-  background-color: #205493;
+  background-color: var(--radfish-primary-blue);
   height: 65vh;
 }
 

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -8,18 +8,76 @@
   text-align: center;
   position: relative;
   overflow: hidden;
+  background-color: #205493;
+  height: 65vh;
 }
 
-[data-theme="dark"] .heroTextColor {
-  color: white;
+.heroBanner::before {
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url("../../static/img/hero-banner.webp");
+  background-size: cover;
+  background-position: bottom;
+  opacity: 0.4;
+}
+
+.heroContainer {
+  position: relative;
+  z-index: 1;
+}
+
+.heroHeading {
+  font-size: 2.5rem;
+}
+
+.heroSubHeading {
+  font-size: 1.2rem;
+}
+
+.heroTextColor {
+  color: #fff;
+}
+
+.heroButtons {
+  flex-direction: column;
 }
 
 [data-theme="dark"] .heroButton {
   background-color: #205493;
+  color: white;
 }
 
-@media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
+@media screen and (min-width: 600px) {
+  .heroHeading {
+    font-size: 3.2rem;
+  }
+  .heroSubHeading {
+    font-size: 1.6rem;
+  }
+  .heroButtons {
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .heroHeading {
+    font-size: 4rem;
+  }
+  .heroSubHeading {
+    font-size: 1.8rem;
+  }
+}
+
+@media screen and (min-width: 996px) {
+  .heroHeading {
+    font-size: 5.5rem;
+  }
+  .heroSubHeading {
+    font-size: 2rem;
   }
 }

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -40,7 +40,7 @@
 }
 
 .heroTextColor {
-  color: #fff;
+  color: white;
 }
 
 .heroButtons {


### PR DESCRIPTION
issue #105 

- Fixes card text color in dark mode
- Added media queries to handle Hero header and subheader
- Fixes hero banner background image color and adds opacity
- Fixes cards overflow on smaller screens


https://github.com/user-attachments/assets/28c00bbe-8072-47fb-8986-a5474d1aa335

