### PR TITLE
Docs - Clean up custom css, use docusaurus themes when possible

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -1,3 +1,4 @@
+import Heading from "@theme/Heading";
 import clsx from "clsx";
 import styles from "./styles.module.css";
 
@@ -7,10 +8,10 @@ function RADFishHero() {
       <div className="container">
         <div className="row">
           <div className={clsx("col col--12 padding-horiz--md")}>
-            <h3 className={styles.heroTitle}>
+            <Heading as="h3" className={styles.heroTitle}>
               Introducing the React Application Development Framework for
               Fisheries (RADFish)
-            </h3>
+            </Heading>
             <p className={styles.heroSubtitle}>
               RADFish, developed by NOAA Fisheries and its partners, is a
               React.js framework designed to streamline the creation and
@@ -74,7 +75,7 @@ function Feature({ title, description }) {
       {/* Card container */}
       <div className={styles.card}>
         <div className="card__header">
-          <h3>{title}</h3>
+          <Heading as="h3">{title}</Heading>
         </div>
         <div className="card__body">
           <p>{description}</p>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -25,14 +25,8 @@
 .heroSubtitle {
   font-size: 1rem;
   font-weight: 300;
-  color: #333;
+  color: var(--radfish-gray-darker);
   margin-bottom: 20px;
-}
-
-.heroDescription {
-  font-size: 1.2rem;
-  line-height: 1.8;
-  color: #666;
 }
 
 .cardContainerRow {
@@ -40,7 +34,7 @@
 }
 
 .card {
-  border: 1px solid #ddd;
+  border: 1px solid var(--radfish-gray-light);
   border-radius: 8px;
   background-color: white;
   padding: 20px;
@@ -66,7 +60,7 @@
 
 .card__body {
   font-size: 1.1rem;
-  color: #666;
+  color: var(--radfish-gray-dark);
   flex-grow: 1;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,6 +7,9 @@
 /* You can override the default Infima variables here. */
 :root {
   --radfish-primary-blue: #205493;
+  --radfish-gray-dark: #666;
+  --radfish-gray-darker: #333;
+  --radfish-gray-light: #ddd;
 
   --ifm-color-primary: #205493;
   --ifm-color-primary-dark: #1d4c84;
@@ -36,7 +39,6 @@
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
-
 .buttons {
   display: flex;
   align-items: center;
@@ -59,17 +61,17 @@
 }
 
 .button--primary:hover {
-    background-color: var(--ifm-color-primary-light);
+  background-color: var(--ifm-color-primary-light);
 }
 
 .button--secondary {
   background-color: var(--ifm-color-secondary);
-  color: #205493;
+  color: var(--radfish-primary-blue);
   padding: 1rem 2rem;
   text-decoration: none;
   font-size: 16px;
 }
 
 .button--secondary:hover {
-    background-color: var(--ifm-color-secondary-light);
+  background-color: var(--ifm-color-secondary-light);
 }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -2,7 +2,6 @@ import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
-
 import Heading from "@theme/Heading";
 import styles from "./index.module.css";
 
@@ -19,9 +18,12 @@ function HomepageHeader() {
         >
           {siteConfig.title}
         </Heading>
-        <p className={clsx(styles.heroSubHeading, styles.heroTextColor)}>
+        <Heading
+          as="h2"
+          className={clsx(styles.heroSubHeading, styles.heroTextColor)}
+        >
           {siteConfig.tagline}
-        </p>
+        </Heading>
         <div className={clsx("buttons", styles.heroButtons)}>
           <Link
             className={clsx("button button--primary", styles.heroButton)}

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -48,7 +48,7 @@
 }
 
 [data-theme="dark"] .heroButton {
-  background-color: #205493;
+  background-color: var(--radfish-primary-blue);
   color: white;
 }
 


### PR DESCRIPTION
issue #102 

- Replace all `h` tags with Docusaurus's `Heading` component
- Create color names at the `:root` to be reusable throughout css files. Example: `--radfish-gray-dark`