### PR TITLE
115 repoint all roadmap links to project board

### DIFF
--- a/docs/about/contribute.md
+++ b/docs/about/contribute.md
@@ -16,7 +16,7 @@ If you encounter any bugs, glitches, or unexpected behavior while using our soft
 
 ### How to Report a Bug:
 
-- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/3) or the Issues Log for that respective repo to ensure the bug hasn’t already been reported.
+- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2/views/3) or the Issues Log for that respective repo to ensure the bug hasn’t already been reported.
 - If it's a new bug, create a new issue using our **Bug Report Template**.
 - Provide as much detail as possible, including the steps to reproduce the bug, the version of the software, and any error messages.
 
@@ -86,7 +86,7 @@ Our documentation is an essential part of helping new users and contributors und
 
 We value your input and welcome ideas that could improve our product\! To ensure your feature request gets the attention it deserves, please follow the steps below. Providing detailed information will help us assess, prioritize, and potentially implement your idea more efficiently.
 
-- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2) or the Issues Log for that respective repo to ensure the feature hasn’t already been requested.
+- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2/views/3) or the Issues Log for that respective repo to ensure the feature hasn’t already been requested.
 - If it's a new feature, create a new issue using our **Feature Request Template**.
 - Provide as much detail as possible to describe the feature.
 
@@ -126,7 +126,7 @@ If you would like to contribute in other ways (e.g., translations, community man
 
 If you want to propose a code change, here are the steps to submit a pull request:
 
-1. First, make sure there is an issue that describes the problem you are solving. Search the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2) to find an existing issue. If none exists, create your own bug report or feature request.
+1. First, make sure there is an issue that describes the problem you are solving. Search the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2/views/3) to find an existing issue. If none exists, create your own bug report or feature request.
 2. Fork this repo into your GitHub account.
 3. Create a branch from directly from your issue submission. Use this branch to do your development.
 4. When your code changes are ready for review, open a pull request. Be sure to fill out all the applicable fields in the generated PR description.
@@ -145,7 +145,7 @@ We review bug reports and feature requests regularly. You can track progress by 
 
 ## 8\. Link to the Roadmap
 
-You can view our [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2). The roadmap outlines our upcoming priorities and major features, helping you understand what we're working on next.
+You can view our [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2/views/3). The roadmap outlines our upcoming priorities and major features, helping you understand what we're working on next.
 
 ## 9\. Code of Conduct
 

--- a/docs/about/contribute.md
+++ b/docs/about/contribute.md
@@ -16,7 +16,7 @@ If you encounter any bugs, glitches, or unexpected behavior while using our soft
 
 ### How to Report a Bug:
 
-- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2) or the Issues Log for that respective repo to ensure the bug hasn’t already been reported.
+- Search through the [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/3) or the Issues Log for that respective repo to ensure the bug hasn’t already been reported.
 - If it's a new bug, create a new issue using our **Bug Report Template**.
 - Provide as much detail as possible, including the steps to reproduce the bug, the version of the software, and any error messages.
 

--- a/docs/about/product-roadmap.md
+++ b/docs/about/product-roadmap.md
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 ## 1\. What is a Project Roadmap?
 
-The RADfish [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2).
+The RADfish [Project Roadmap](https://github.com/orgs/NMFS-RADFish/projects/2/views/3).
 
 In the context of open-source projects like RADFish, a project roadmap is a high-level strategic guide that outlines the major features, improvements, and goals that the project intends to achieve over time. It serves as a visual timeline that highlights the project’s direction and provides insights into what the community can expect in future releases. The roadmap not only details upcoming work but also helps to set expectations, prioritize tasks, and track progress against defined goals.
 


### PR DESCRIPTION
Changed over the links to the Roadmap to be the roadmap view in the projects board, instead of the backlog.