### PR TITLE
Move scripts to Avail Scripts Page

### DIFF
--- a/docs/developer-documentation/building-your-application/available-scripts/available-scripts.md
+++ b/docs/developer-documentation/building-your-application/available-scripts/available-scripts.md
@@ -1,53 +1,41 @@
 # Available Scripts
 
-## `npm start`
+**`npm start`**
 
-Runs the app in the development mode. Open [http://localhost:3000](http://localhost:3000/) to view it in the browser.
+This script starts the Vite development server. It runs the app locally with hot module reloading, allowing for fast development and instant updates as you make changes. Open [http://localhost:3000](http://localhost:3000/) to view it in the browser.
 
-The page will reload if you make edits. You will also see any lint errors in the console.
+**`npm run build`**
 
-## `npm test`
+Builds the project for production by using Vite’s build tool. It generates optimized static assets, such as HTML, CSS, and JavaScript, which are output to the dist directory.
 
-Launches the test runner in the interactive watch mode.
+**`npm run prebuild`**
 
-## `npm run build`
+Before the build process starts, this script ensures that the dist folder (which contains the previous build) is deleted. This helps prevent old build files from being included in the new build.
 
-Builds the app for production to the `build` folder. It correctly bundles React in production mode and optimizes the build for the best performance.
+**`npm test`**
 
-## `npm run serve`
+Runs unit and integration tests using Vitest, while excluding end-to-end (e2e) tests located in the `./src/__tests__/e2e/` directory. It ensures that regular tests are executed separately from e2e tests.
 
-Runs the production bundle (created in command above) and serves static files, simulating a production server. This is helpful when testing and building things where "offline mode" is a feature being developed.
+**`npm test:e2e`**
 
-# Scaffold project
+Runs end-to-end (e2e) tests located in `./src/__tests__/e2e/integration.e2e.test.jsx`. This script uses concurrently to run the Vite server and e2e tests in parallel, automatically stopping other processes if one succeeds.
 
-```
-npx @nmfs-radfish/create-radfish-app my-app
-```
+**`npm run lint`**
 
-After creation, your project should look like this:
+Runs ESLint with the `--fix` option, which automatically fixes certain linting issues in the code found in the src/ directory.
 
-```
-my-app
-├── babel.config.js
-├── index.html
-├── mocks
-│   ├── browser.js
-│   └── handlers.js
-├── node_modules/
-├── package-lock.json
-├── package.json
-├── public
-│   ├── icons
-│   ├── manifest.json
-│   ├── mockServiceWorker.js
-│   ├── noaafavicon.png
-│   └── robots.txt
-├── src
-│   ├── App.jsx
-│   ├── index.css
-│   ├── index.jsx
-│   ├── pages
-│   ├── service-worker.js
-│   └── styles
-└── vite.config.js
-```
+**`npm run format`**
+
+Formats the code in the `src/` directory using Prettier according to the configuration specified in the `.prettierrc` file. This ensures consistent code formatting across the project.
+
+**`npm run serve`**
+
+This script starts a local server to preview the production build. It serves the files from the `dist/` folder, allowing you to check how the app will behave in a production environment.
+
+**`npm run lhci:mobile`**
+
+Runs **Lighthouse CI (LHCI)** on the application, collecting performance metrics and scores for mobile devices. It automates performance auditing to ensure the app meets mobile optimization standards.
+
+**`npm run lhci:desktop`**
+
+Runs **Lighthouse CI (LHCI)** on the application, collecting performance metrics and scores for desktop devices. This script is similar to lhci:mobile but targets desktop performance.

--- a/docs/developer-documentation/getting-started.md
+++ b/docs/developer-documentation/getting-started.md
@@ -75,47 +75,13 @@ npx @nmfs-radfish/create-radfish-app --help
     ```bash
     npm test
     ```
-Please visit [updgrading](./upgrading.md) for more information. 
+Please visit [upgrading](./upgrading.md) for more information. 
 # Scripts
 
 **`npm start`**
 
-This script starts the Vite development server. It runs the app locally with hot module reloading, allowing for fast development and instant updates as you make changes.
+This script starts the Vite development server. It runs the app locally with hot module reloading, allowing for fast development and instant updates as you make changes. Open [http://localhost:3000](http://localhost:3000/) to view it in the browser.
 
-**`npm run build`**
-
-Builds the project for production by using Vite’s build tool. It generates optimized static assets, such as HTML, CSS, and JavaScript, which are output to the dist directory.
-
-**`npm run prebuild`**
-
-Before the build process starts, this script ensures that the dist folder (which contains the previous build) is deleted. This helps prevent old build files from being included in the new build.
-
-**`npm test`**
-
-Runs unit and integration tests using Vitest, while excluding end-to-end (e2e) tests located in the `./src/__tests__/e2e/` directory. It ensures that regular tests are executed separately from e2e tests.
-
-**`npm test:e2e`**
-
-Runs end-to-end (e2e) tests located in `./src/__tests__/e2e/integration.e2e.test.jsx`. This script uses concurrently to run the Vite server and e2e tests in parallel, automatically stopping other processes if one succeeds.
-
-**`npm run lint`**
-
-Runs ESLint with the `--fix` option, which automatically fixes certain linting issues in the code found in the src/ directory.
-
-**`npm run format`**
-
-Formats the code in the `src/` directory using Prettier according to the configuration specified in the `.prettierrc` file. This ensures consistent code formatting across the project.
-
-**`npm run serve`**
-
-This script starts a local server to preview the production build. It serves the files from the `dist/` folder, allowing you to check how the app will behave in a production environment.
-
-**`npm run lhci:mobile`**
-
-Runs **Lighthouse CI (LHCI)** on the application, collecting performance metrics and scores for mobile devices. It automates performance auditing to ensure the app meets mobile optimization standards.
-
-**`npm run lhci:desktop`**
-
-Runs **Lighthouse CI (LHCI)** on the application, collecting performance metrics and scores for desktop devices. This script is similar to lhci:mobile but targets desktop performance.
+See [Available Scripts](./building-your-application/available-scripts/available-scripts.md) for full list of commands.
 
 Now that you are up and running, see the [Components & Usage](./building-your-application/patterns/components.md) section to start building out your first pages!


### PR DESCRIPTION
- Moved majority of scripts from Getting Started to Avail Scripts page (but kept npm start). 
- Removed scaffolding/output from Avail Scripts 
- Fixed a typo on Getting Started