### PR TITLE
Fix remote content image requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ yarn-error.log*
 
 # Remote Content
 /docs/**/examples/**/*.md
+/docs/**/examples/**/*.png

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,6 +54,17 @@ const config = {
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "computed-form-fields-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/computed-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["computed-form-fields.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // Computed Form Fields
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/computed-form-fields#readme
@@ -74,6 +85,17 @@ id: computed-form-fields
 ${content}`,
           };
         },
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+          // options here
+          name: "conditional-form-fields-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/conditional-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["conditional-form-fields.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
       },
     ],
     [
@@ -104,6 +126,17 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "field-validators-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/field-validators/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["field-validators.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // Field Validators
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/field-validators#readme
@@ -124,6 +157,17 @@ id: field-validators
 ${content}`,
           };
         },
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+          // options here
+          name: "network-status-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/network-status/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["network-status.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
       },
     ],
     [
@@ -154,6 +198,17 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "mock-api-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/mock-api/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["mock-api.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // Mock API
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/mock-api#readme
@@ -179,6 +234,17 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "on-device-storage-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/on-device-storage/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["on-device-storage.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],    
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // On Device Storage
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/on-device-storage#readme
@@ -199,6 +265,17 @@ id: on-device-storage
 ${content}`,
           };
         },
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+          // options here
+          name: "multistep-form-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/multistep-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["multistep.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
       },
     ],
     [
@@ -229,6 +306,17 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "server-sync-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/server-sync/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["server-sync.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],    
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // ServerSync
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/server-sync#readme
@@ -251,6 +339,17 @@ ${content}`,
         },
       },
     ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+          // options here
+          name: "react-query-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/react-query/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["react-query.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],    
     [
       "docusaurus-plugin-remote-content",
       {
@@ -279,6 +378,17 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
+          // options here
+          name: "persisted-form-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/persisted-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["persisted-form.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
+      },
+    ],    
+    [
+      "docusaurus-plugin-remote-content",
+      {
         // Persisted Form
         // Remote content configuration to fetch repo README.md for 
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/persisted-form#readme
@@ -299,6 +409,17 @@ id: persisted-form
 ${content}`,
           };
         },
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+          // options here
+          name: "simple-table-image-content", // used by CLI, must be path safe
+          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/simple-table/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+          documents: ["simple-table.png"], // the file names to download
+          requestConfig: { responseType: "arraybuffer" }
       },
     ],
     [


### PR DESCRIPTION
Remote content was not configured to pull in the images that are referenced by the example READMEs.

This should resolve current build issues:
- https://github.com/NMFS-RADFish/radfish/actions/runs/11562879538/job/32184997282#step:5:100
- https://github.com/NMFS-RADFish/radfish/actions/runs/11563534596/job/32187023487#step:5:100