### PR TITLE
147 docs   add permit example documentation

### DIFF
--- a/docs/developer-documentation/examples-and-templates/examples-and-templates.md
+++ b/docs/developer-documentation/examples-and-templates/examples-and-templates.md
@@ -17,6 +17,7 @@ Below are a list of pre-built examples that you can use as a starting point for 
 1. [Computed Form Fields](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/computed-form-fields/README.md)
 1. [Conditional Form Fields](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/conditional-form-fields/README.md)
 1. [Field Validators](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/field-validators/README.md)
+1. [Form Structure](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/form-structure/README.md)
 1. [Mock API](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/mock-api/README.md)
 1. [Multistep Form](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/multistep-form/README.md)
 1. [Network Status](https://github.com/NMFS-RADFish/boilerplate/blob/main/examples/network-status/README.md)
@@ -41,7 +42,7 @@ Note: The `react-javascript` template is the default, so running `npx @nmfs-radf
 
 Once you scaffold a new template radfish app, you will be given the following file structure:
 
-``` bash
+```bash
 my-app
 ├── babel.config.js
 ├── index.html
@@ -62,10 +63,10 @@ my-app
 │   ├── index.css
 │   ├── index.jsx
 │   ├── pages
-│       └── Home.jsx 
+│       └── Home.jsx
 │   ├── service-worker.js
 │   └── styles
-│       └── theme.css 
+│       └── theme.css
 └── vite.config.js
 ```
 
@@ -90,7 +91,6 @@ Contains files related to mocking API requests for development and testing purpo
 - **`mocks/browser.js`** Sets up and configures the mock service worker for the browser environment. It intercepts network requests during development to simulate API responses without needing a real backend.
 
 - **`mocks/handlers.js`** Defines request handlers for the mock service worker. Each handler specifies how to respond to certain API requests, allowing you to test different scenarios and data flows.
-
 
 #### public/
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -54,19 +54,21 @@ const config = {
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "computed-form-fields-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/computed-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["computed-form-fields.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "computed-form-fields-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/computed-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["computed-form-fields.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Computed Form Fields
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/computed-form-fields#readme
         name: "computed-form-fields", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -90,19 +92,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "conditional-form-fields-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/conditional-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["conditional-form-fields.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "conditional-form-fields-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/conditional-form-fields/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["conditional-form-fields.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Conditional Form Fields
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/conditional-form-fields#readme
         name: "conditional-form-fields", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -126,19 +130,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "field-validators-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/field-validators/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["field-validators.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "field-validators-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/field-validators/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["field-validators.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Field Validators
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/field-validators#readme
         name: "field-validators", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -162,19 +168,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "network-status-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/network-status/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["network-status.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "network-status-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/network-status/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["network-status.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Network Status
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/network-status#readme
         name: "network-status", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -198,19 +206,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "mock-api-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/mock-api/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["mock-api.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "mock-api-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/mock-api/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["mock-api.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Mock API
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/mock-api#readme
         name: "mock-api", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -234,19 +244,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "on-device-storage-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/on-device-storage/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["on-device-storage.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "on-device-storage-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/on-device-storage/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["on-device-storage.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
-    ],    
+    ],
     [
       "docusaurus-plugin-remote-content",
       {
         // On Device Storage
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/on-device-storage#readme
         name: "on-device-storage", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -270,19 +282,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "multistep-form-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/multistep-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["multistep.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "multistep-form-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/multistep-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["multistep.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Multistep Form
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/multistep-form#readme
         name: "multistep-form", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -306,19 +320,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "server-sync-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/server-sync/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["server-sync.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "server-sync-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/server-sync/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["server-sync.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
-    ],    
+    ],
     [
       "docusaurus-plugin-remote-content",
       {
         // ServerSync
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/server-sync#readme
         name: "server-sync", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -342,19 +358,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "react-query-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/react-query/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["react-query.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "react-query-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/react-query/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["react-query.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
-    ],    
+    ],
     [
       "docusaurus-plugin-remote-content",
       {
         // React Query
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/react-query#readme
         name: "react-query", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -378,19 +396,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "persisted-form-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/persisted-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["persisted-form.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "persisted-form-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/persisted-form/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["persisted-form.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
-    ],    
+    ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Persisted Form
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/persisted-form#readme
         name: "persisted-form", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -414,19 +434,21 @@ ${content}`,
     [
       "docusaurus-plugin-remote-content",
       {
-          // options here
-          name: "simple-table-image-content", // used by CLI, must be path safe
-          sourceBaseUrl: "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/simple-table/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
-          outDir: "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
-          documents: ["simple-table.png"], // the file names to download
-          requestConfig: { responseType: "arraybuffer" }
+        // options here
+        name: "simple-table-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/simple-table/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["simple-table.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
       },
     ],
     [
       "docusaurus-plugin-remote-content",
       {
         // Simple Table
-        // Remote content configuration to fetch repo README.md for 
+        // Remote content configuration to fetch repo README.md for
         // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/simple-table#readme
         name: "simple-table", // used by CLI, must be path safe
         sourceBaseUrl:
@@ -536,9 +558,9 @@ ${content}`,
 
 export default config;
 
-// This function path stub to a README.md file 
+// This function path stub to a README.md file
 // and returns the .md renamed as the parent folder.
 // eg. "network-status/README.md" --> "network-status.md"
 function readmeToNamedMd(filename) {
   return filename.split("/")[0].concat(".md");
-};
+}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -447,6 +447,44 @@ ${content}`,
         },
       },
     ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+        // options here
+        name: "form-structure-image-content", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/form-structure/src/assets/", // the base url for the markdown (gets prepended to all of the documents when fetching)
+        outDir:
+          "docs/developer-documentation/examples-and-templates/examples/src/assets", // the base directory to output to.
+        documents: ["form-structure.png"], // the file names to download
+        requestConfig: { responseType: "arraybuffer" },
+      },
+    ],
+    [
+      "docusaurus-plugin-remote-content",
+      {
+        // Structured Form
+        // Remote content configuration to fetch repo README.md for
+        // https://github.com/NMFS-RADFish/boilerplate/tree/main/examples/form-structure#readme
+        name: "form-structure", // used by CLI, must be path safe
+        sourceBaseUrl:
+          "https://raw.githubusercontent.com/NMFS-RADFish/boilerplate/main/examples/",
+        outDir: "docs/developer-documentation/examples-and-templates/examples/", // the base directory to output to.
+        documents: ["form-structure/README.md"], // the file to download
+        modifyContent(filename, content) {
+          return {
+            filename: readmeToNamedMd(filename),
+            content: `---
+description: This example demonstrates how build a non-trivial form using Trussworks components.
+title: Form Structure
+id: form-structure
+---
+
+${content}`,
+          };
+        },
+      },
+    ],
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */


### PR DESCRIPTION
Depends on https://github.com/NMFS-RADFish/boilerplate/pull/473
This code add a reference to a file that is added by the above PR.

Adds `remote-content` configuration for `form-structure` example.

- README.md
- src/assets/form-structure.png 