### PR TITLE
Add code diff highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -559,6 +559,16 @@ ${content}`,
       prism: {
         theme: prismThemes.github,
         darkTheme: prismThemes.dracula,
+        magicComments: [
+          {
+            className: 'code-block-diff-add-line',
+            line: 'diff-add'
+          },
+          {
+            className: 'code-block-diff-remove-line',
+            line: 'diff-remove'
+          }
+        ]
       },
     }),
 };

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -86,3 +86,51 @@
 .button--secondary:hover {
   background-color: var(--ifm-color-secondary-light);
 }
+
+/* Code diff highlighting start */
+.code-block-diff-add-line {
+  background-color: #ccffd8;
+  display: block;
+  margin: 0 -40px;
+  padding: 0 40px;
+}
+
+.code-block-diff-add-line::before {
+  position: absolute;
+  left: 8px;
+  padding-right: 8px;
+  content: '+';
+}
+
+.code-block-diff-remove-line {
+  background-color: #ffebe9;
+  display: block;
+  margin: 0 -40px;
+  padding: 0 40px;
+}
+
+.code-block-diff-remove-line::before {
+  position: absolute;
+  left: 8px;
+  padding-right: 8px;
+  content: '-';
+}
+
+/**
+ * use magic comments to mark diff blocks
+ */
+pre code:has(.code-block-diff-add-line) {
+  padding-left: 40px!important;
+}
+
+pre code:has(.code-block-diff-remove-line) {
+  padding-left: 40px!important;
+}
+
+[data-theme="dark"] pre code .token-line.code-block-diff-add-line {
+  background-color: #4A5827;
+}
+[data-theme="dark"] pre code .token-line.code-block-diff-remove-line {
+  background-color: #542936;
+}
+/* Code diff highlighting end */


### PR DESCRIPTION
Adds syntax highlighting for code diffs in markdown:

Light
![image](https://github.com/user-attachments/assets/b2d8a363-76f9-4d88-af58-451540594fe7)


Dark
![image](https://github.com/user-attachments/assets/4239771c-3e27-46d7-81b9-6eb72d51ae8d)

Markdown
`````mdx
```jsx
function HighlightSomeText(highlight) {
  if (highlight) {
    // diff-remove
    console.log('Highlighted text found');
    // diff-add
    console.log('Highlighted text found');
    return 'This text is highlighted!';
  }

  return 'Nothing highlighted';
}
```
`````