### PR TITLE
fix: update documentation URLs from old org to new org

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,47 +1,25 @@
-name: Deploy to GitHub Pages
+name: Deploy Redirect to GitHub Pages
 
 on:
   push:
     branches:
       - main
+
 jobs:
-  build:
-    name: Build Docusaurus
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install dependencies
-        run: npm install
-      - name: Build website
-        run: npm run build
-
-      - name: Upload Build Artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: build
-
   deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    runs-on: ubuntu-latest
     permissions:
-      pages: write # to deploy to Pages
-      id-token: write # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
-    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - name: Upload redirect pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./redirect
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/redirect/404.html
+++ b/redirect/404.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RADFish Documentation has moved</title>
+  <script>
+    // Preserve the path so users land on the equivalent page at the new site
+    var newBase = "https://nmfs-ocio.github.io";
+    window.location.replace(newBase + window.location.pathname + window.location.search + window.location.hash);
+  </script>
+  <meta http-equiv="refresh" content="3; url=https://nmfs-ocio.github.io/radfish/">
+  <link rel="canonical" href="https://nmfs-ocio.github.io/radfish/">
+</head>
+<body>
+  <p>RADFish documentation has moved to
+    <a href="https://nmfs-ocio.github.io/radfish/">https://nmfs-ocio.github.io/radfish/</a>.
+  </p>
+</body>
+</html>

--- a/redirect/index.html
+++ b/redirect/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>RADFish Documentation has moved</title>
+  <meta http-equiv="refresh" content="0; url=https://nmfs-ocio.github.io/radfish/">
+  <link rel="canonical" href="https://nmfs-ocio.github.io/radfish/">
+</head>
+<body>
+  <p>RADFish documentation has moved to
+    <a href="https://nmfs-ocio.github.io/radfish/">https://nmfs-ocio.github.io/radfish/</a>.
+  </p>
+</body>
+</html>


### PR DESCRIPTION
## Problem

- RADFish documentation has moved from `NMFS-RADFish` to `nmfs-ocio` GitHub organization

## Fix

- Added `redirect/index.html` with instant meta-refresh redirect to `nmfs-ocio.github.io/radfish/`
- Added `redirect/404.html` that catches deep links and preserves the URL path on redirect
- Updated `.github/workflows/deploy.yml` to deploy static redirect files instead of building Docusaurus
