### PR TITLE
docs: update npm configuration instructions for npmrc file

### DIFF
--- a/docs/developer-documentation/getting-started.mdx
+++ b/docs/developer-documentation/getting-started.mdx
@@ -34,15 +34,17 @@ The GitHub Package Registry requires additional setup:
 
    For more details, see the [GitHub documentation on creating a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic).
 
-2. **Configure `.npmrc` for authentication.** Run the following command, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with the token you copied:
+2. **Configure `.npmrc` for authentication.** Run the following commands, replacing `YOUR_PERSONAL_ACCESS_TOKEN` with the token you copied:
 
    ```bash
+   npm config set @nmfs-ocio:registry https://npm.pkg.github.com
    npm config set //npm.pkg.github.com/:_authToken YOUR_PERSONAL_ACCESS_TOKEN
    ```
 
    Alternatively, you can manually edit `~/.npmrc` and add:
 
    ```
+   @nmfs-ocio:registry=https://npm.pkg.github.com
    //npm.pkg.github.com/:_authToken=YOUR_PERSONAL_ACCESS_TOKEN
    ```
 


### PR DESCRIPTION
Adds `@nmfs-ocio:registry=https://npm.pkg.github.com` to the Getting Started guide's `.npmrc` setup steps. Without this line, npm doesn't know to resolve @nmfs-ocio packages from the GitHub Package Registry, the auth token alone isn't sufficient.