### PR TITLE
chore: update getting started docs for npm deprecation

### DIFF
--- a/docs/developer-documentation/getting-started.mdx
+++ b/docs/developer-documentation/getting-started.mdx
@@ -74,7 +74,7 @@ No additional setup is needed. RADFish packages are publicly available on the np
 
 ## Quick Start
 
-### Option 1: Scaffold a new app from a template
+### Scaffold a new app from a template
 
 Start your app with a barebones and pre-configured [template](./examples-and-templates#templates).
 
@@ -95,72 +95,6 @@ Once the development server starts, visit http://localhost:3000/ in your browser
 ```bash
 npx @nmfs-radfish/create-radfish-app@latest my-app
 cd my-app
-npm start
-```
-
-Once the development server starts, visit http://localhost:3000/ in your browser to see your app.
-
-</TabItem>
-</Tabs>
-
-### Option 2: Scaffold a new app from an example
-
-Select an [example](/radfish/developer-documentation/examples-and-templates) and run [the command](./building-your-application/available-scripts/running-example.md) using the `--example` tag.
-
-<Tabs groupId="registry">
-<TabItem value="github" label="GitHub" default>
-
-```bash
-npx @nmfs-ocio/create-radfish-app my-app --example multistep-form
-cd my-app
-npm start
-```
-
-</TabItem>
-<TabItem value="npm" label="npm">
-
-```bash
-npx @nmfs-radfish/create-radfish-app my-app --example multistep-form
-cd my-app
-npm start
-```
-
-</TabItem>
-</Tabs>
-
-### Option 3: Clone the monorepo repository to access all examples
-
-To get all the examples, clone the [monorepo repository](https://github.com/nmfs-ocio/monorepo):
-
-<Tabs groupId="registry">
-<TabItem value="github" label="GitHub" default>
-
-```bash
-git clone git@github.com:nmfs-ocio/radfish-monorepo.git
-```
-
-Then navigate to the example you want to run and start the app:
-
-```bash
-cd radfish-monorepo/examples/[example you want to run]
-npm install
-npm start
-```
-
-Once the development server starts, visit http://localhost:3000/ in your browser to see your app.
-
-</TabItem>
-<TabItem value="npm" label="npm">
-
-```bash
-git clone https://github.com/nmfs-ocio/monorepo.git
-```
-
-Then navigate to the example you want to run and start the app:
-
-```bash
-cd monorepo/examples/[example you want to run]
-npm install
 npm start
 ```
 

--- a/docs/developer-documentation/getting-started.mdx
+++ b/docs/developer-documentation/getting-started.mdx
@@ -59,6 +59,14 @@ The GitHub Package Registry requires additional setup:
 </TabItem>
 <TabItem value="npm" label="npm">
 
+:::danger Deprecation Notice
+
+The `@nmfs-radfish` packages on the public npm registry have been deprecated and are no longer receiving updates. All future releases will be published exclusively to GitHub Packages under the `@nmfs-ocio` scope.
+
+Please migrate to the GitHub Package Registry by following the **GitHub** tab instructions above. For existing projects, refer to the [migration guide](./upgrading.md#migrating-from-nmfs-radfish-to-nmfs-ocio).
+
+:::
+
 No additional setup is needed. RADFish packages are publicly available on the npm.
 
 </TabItem>

--- a/docs/developer-documentation/getting-started.mdx
+++ b/docs/developer-documentation/getting-started.mdx
@@ -93,7 +93,7 @@ Once the development server starts, visit http://localhost:3000/ in your browser
 <TabItem value="npm" label="npm">
 
 ```bash
-npx @nmfs-radfish/create-radfish-app my-app
+npx @nmfs-radfish/create-radfish-app@latest my-app
 cd my-app
 npm start
 ```


### PR DESCRIPTION
## Problem

- The Getting Started page did not communicate that `@nmfs-radfish` packages on the public npm registry are deprecated, leaving users without guidance on which registry to use going forward
- The `npx` command in the npm tab did not pin to `@latest`, so users could resolve a stale cached version of `create-radfish-app`
- The Quick Start section listed three scaffolding options (template, example, monorepo clone) which added noise and obscured the recommended path

## Fix

- Added a `:::danger` deprecation notice to the npm tab in `getting-started.mdx` directing users to the GitHub Package Registry and linking to the migration guide
- Updated the npm tab's scaffolding command to `npx @nmfs-radfish/create-radfish-app@latest my-app` so users always pull the most recent published version
- Removed Options 2 and 3 from Quick Start and renamed the remaining option to "Scaffold a new app from a template" to surface the primary path

<img width="1215" height="1215" alt="Screenshot 2026-05-14 at 10 59 56 AM" src="https://github.com/user-attachments/assets/c11005cf-c6a6-40ca-aeaa-071b33dcf4bd" />
