### PR TITLE
fix: lesson 4 tutorial code errors in catch add/delete/edit

### DIFF
--- a/docs/tutorial/lesson-4.mdx
+++ b/docs/tutorial/lesson-4.mdx
@@ -151,7 +151,7 @@ import {
   COLLECTION_NAMES,
 } from "../utils";
 import { useTripNavigation, useTripData, useCatchData } from "../hooks";
-import { Layout } from "../components/Layout";
+import Layout from "../components/Layout";
 ```
 
 **Understanding the Provided Imports:**
@@ -915,7 +915,7 @@ Let's examine the provided `updateCatch` function that handles updating individu
     const catchToUpdate = catches[index];
     
     try {
-      const tripStore = app.stores[STORE_NAMES.TRIP];
+      const tripStore = app.stores[STORE_NAMES.TRIP_STORE];
       const catchCollection = tripStore.getCollection(COLLECTION_NAMES.CATCH_COLLECTION);
 
       // Prepare data for update (ensure correct types)
@@ -1011,7 +1011,7 @@ The delete functionality is also provided with proper separation of concerns, in
     const catchToDelete = catches[index];
     
     try {
-      const tripStore = app.stores[STORE_NAMES.TRIP];
+      const tripStore = app.stores[STORE_NAMES.TRIP_STORE];
       const catchCollection = tripStore.getCollection(COLLECTION_NAMES.CATCH_COLLECTION);
 
       // Remove from RADFish/IndexedDB
@@ -1064,7 +1064,7 @@ The recorded catch handlers involve advanced patterns like direct database acces
 
 ## Step 7: Testing the Complete Implementation
 
-After implementing the 5 event handlers (handleInputChange, handleTimeChange, resetForm, handleSubmit, and handleMainSubmit), let's test both adding new catches and managing recorded catches.
+After implementing the 5 event handlers (handleInputChange, handleTimeChange, resetForm, handleAddCatch, and handleSubmit), let's test both adding new catches and managing recorded catches.
 
 ### 7.1: Test Adding New Catches
 


### PR DESCRIPTION
- Corrected `updateCatch` and `deleteCatch` reference blocks to use `STORE_NAMES.TRIP_STORE` instead of the undefined `STORE_NAMES.TRIP`, which caused `TypeError: Cannot read properties of undefined (reading 'getCollection')` when deleting or editing a recorded catch.
- Fixed the `Layout` import to use a default import (`import Layout from ...`) matching its actual export.
- Corrected a prose typo listing the five event handlers (`handleMainSubmit` → `handleAddCatch`).
